### PR TITLE
Allow specifying repo branch without subdirectory

### DIFF
--- a/caasw.py
+++ b/caasw.py
@@ -235,7 +235,7 @@ def getjobid():
 
 # this is writen by GPT
 def extract_github_url(url):
-    pattern = re.compile(r"https://github\.com/(?P<owner>[^/]+)/(?P<repo>[^/]+)(?:/tree/(?P<branch>[^/]+)/(?P<dir>.+))?")
+    pattern = re.compile(r"^https://github\.com/(?P<owner>[^/]+)/(?P<repo>[^/]+)(?:/tree/(?P<branch>[^/]+)(?:/(?P<dir>.+))?)?$")
     match = pattern.search(url)
     
     if match:


### PR DESCRIPTION
This allows specifying repo branch without subdirectory. Shown below is my local run using:
Giturl = https://github.com/AngeloJacobo/UberDDR3/tree/dev_max_freq

<img width="1446" height="1008" alt="image" src="https://github.com/user-attachments/assets/3b05a104-bf3b-4cdf-8b8c-a4daa3e3f0e9" />


